### PR TITLE
Add functionality to close a connection

### DIFF
--- a/src/Mode/Mode.php
+++ b/src/Mode/Mode.php
@@ -29,6 +29,14 @@ abstract class Mode
     }
 
     /**
+     * Closes the connection resource.
+     */
+    public function closeResource()
+    {
+        fclose($this->resource);
+    }
+
+    /**
      * @param CommandInterface $command
      */
     public function addCommand(CommandInterface $command)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no 
| Tickets       | none
| License       | MIT

Allows to close a connection directly via the Mode instance.
This improves the testability of label print code, as the printer
and its dependencies can be replaced with mocks in unit/integration tests.

The original direct fclose() call according to the docs would prevent such uses.